### PR TITLE
feat: universal /mc commands for all projects

### DIFF
--- a/commands/mcimplement.md
+++ b/commands/mcimplement.md
@@ -1,0 +1,102 @@
+# /mcimplement — Implement, Review, and Merge
+
+When the user sends `/mcimplement <issue_numbers>`, execute this automated workflow for each issue sequentially.
+
+## Arguments
+- `<issue_numbers>` — One or more GitHub issue numbers, space-separated (required)
+- Examples: `/mcimplement 42` or `/mcimplement 42 43 44`
+
+## Scoping
+
+1. Read `IDENTITY.md` to determine your role and project.
+2. **If Project Lead:** Use your project config from `~/.config/motley-crew/projects/<project>.json`.
+3. **If Chief of Staff:** The user must specify which project, or infer from the issue number by checking all project repos.
+
+Get the repo path and GitHub repo from the project config:
+```json
+{
+  "repo": "git@github.com:toolguard/toolguard.git",
+  "checkout_path": "~/projects/toolguard/lead/"
+}
+```
+
+## GitHub token
+```bash
+TOKEN=$(cat ~/.config/motley-crew/github-token)
+```
+
+## Workflow
+
+### Step 1: Fetch Issue Details
+```bash
+curl -s -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/<owner>/<repo>/issues/<issue_number>"
+```
+Extract title, body, and labels. Confirm to user what's being implemented.
+
+### Step 2: Sonnet Implements
+Spawn a sub-agent (Sonnet, default model) with label `impl-<issue_number>`:
+- Read the issue details
+- Read relevant source files in the project checkout
+- Create branch `feature/<descriptive-name>` or `fix/<descriptive-name>` off main
+- Implement the fix/feature
+- Run build and test commands from project config (or detect from repo)
+- Commit and push
+- Open a PR against main with clear description referencing the issue
+- **Report back** with: branch name, PR number, files changed, test results, design decisions
+
+Timeout: 900s (15 min). If it times out, check for uncommitted work and finish manually.
+
+### Step 3: Opus Reviews
+Once Sonnet's PR is ready, spawn an Opus sub-agent with label `review-<issue_number>`:
+- Model: `anthropic/claude-opus-4-6`
+- Review the full diff: `git diff main <branch>`
+- Focus on: security, correctness, race conditions, edge cases, code style
+- **Report back** with: findings list, verdict (APPROVE / APPROVE WITH MINOR FIXES / REQUEST CHANGES)
+
+Timeout: 450s (7.5 min).
+
+### Step 4: Handle Review Result
+
+**If APPROVE:** Go to Step 6 (merge).
+
+**If APPROVE WITH MINOR FIXES:**
+- Fix the minor issues directly (no sub-agent needed for small fixes)
+- Commit and push
+- Go to Step 6 (merge)
+
+**If REQUEST CHANGES:**
+- Fix all issues listed by Opus (directly if straightforward, or spawn Sonnet if complex)
+- Commit and push
+- Go back to Step 3 (Opus re-reviews)
+- Maximum 3 review cycles — if still not passing, report to user for manual intervention
+
+### Step 5: (Loop back to Step 3 if needed)
+
+### Step 6: Merge
+```bash
+cd <checkout_path>
+git checkout main && git merge <branch> && git push origin main
+```
+Close the GitHub issue:
+```bash
+curl -s -X PATCH -H "Authorization: token $TOKEN" \
+  "https://api.github.com/repos/<owner>/<repo>/issues/<issue_number>" \
+  -d '{"state":"closed"}'
+```
+
+### Step 7: Report
+Tell user: issue closed, PR merged, summary of what was done.
+
+## Multiple Issues
+1. Process **sequentially** — finish one completely before starting the next
+2. After each: report status (e.g. "✅ #42 done. Starting #43...")
+3. If one fails after max review cycles, skip it, report failure, continue
+4. Final summary of all issues: succeeded, failed, skipped
+
+## Key Rules
+- **Never run parallel sub-agents on the same repo** — they clobber each other's branches
+- **Sub-agents must always report back** — silence is not acceptable
+- **Sonnet implements, Opus reviews** — never the other way around
+- **All tests must pass** before PR and before merge
+- **Max 3 review cycles** — escalate to human if stuck

--- a/commands/mcstatus.md
+++ b/commands/mcstatus.md
@@ -1,0 +1,52 @@
+# /mcstatus — Open Issues Status Email
+
+When the user sends `/mcstatus`, execute this workflow.
+
+## Scoping
+
+1. Read `IDENTITY.md` to determine your role.
+2. **If Project Lead:** Read your project config from `~/.config/motley-crew/projects/<project>.json` to get the repo URL.
+3. **If Chief of Staff:** Iterate over all `~/.config/motley-crew/projects/*.json` files for a cross-project view.
+
+## Steps
+
+### 1. Fetch open issues
+
+For each repo in scope:
+```bash
+TOKEN=$(cat ~/.config/motley-crew/github-token)
+REPO="<owner>/<repo>"  # from project config
+curl -s -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/$REPO/issues?state=open&per_page=100"
+```
+Filter out pull requests (items with `pull_request` key).
+
+### 2. Build HTML email
+
+- **Sort order:** `botblocker`-labeled first (red background), then `human`-labeled (yellow background), then rest. Within groups, sort by milestone priority then issue number.
+- **HTML table columns:** `#`, `Title` (linked), `Labels`, `Milestone`, `Status/Deps`
+- If CoS (multi-project): group issues by project with `<h3>` headers
+- **Summary line** with counts: open, botblockers, human action needed
+- **All commentary goes BELOW the table** — recently closed, action items, critical path notes
+
+### 3. Send via email
+
+Use the ToolGuard shim to send:
+```bash
+echo '<MCP JSON>' | ~/.toolguard/bin/toolguard shim --config ~/.toolguard/toolguard.yaml 2>/dev/null
+```
+- **To:** john.lombardo@gmail.com
+- **Subject:** `Motley Crew — <Project> Issues (<date>)` (or `All Projects` for CoS)
+- **body_format:** html
+- **user_google_email:** atari400clawbot@gmail.com
+
+If the shim is not available (ToolGuard not installed), fall back to posting the summary directly in the Discord channel as a message.
+
+### 4. Confirm
+
+Tell the user the email was sent (or that you posted the summary to Discord).
+
+## Notes
+- Parse dependency info from issue bodies when available
+- Color coding: `botblocker` red (#ffcccc), `human` yellow (#fff3cd)
+- Include recently closed issues (last 10) below the table

--- a/commands/mcworker.md
+++ b/commands/mcworker.md
@@ -1,0 +1,58 @@
+# /mcworker — Spawn a Worker
+
+When the user sends `/mcworker <template>`, spawn a new permanent worker for this project.
+
+## Arguments
+- `<template>` — Worker template name (required). e.g., `dev-sonnet`, `reviewer-opus`, `qa-sonnet`
+- Examples: `/mcworker dev-sonnet` or `/mcworker reviewer-opus`
+
+## Scoping
+
+1. Read `IDENTITY.md` to determine your project.
+2. Read project config from `~/.config/motley-crew/projects/<project>.json` to get the repo URL.
+3. **This command only works for Project Leads**, not the CoS.
+
+## Workflow
+
+### Step 1: Validate template
+Check that the template exists:
+```bash
+ls ~/motley-crew/templates/<template>.md
+```
+If not found, list available templates and ask the user to pick one.
+
+### Step 2: Run spawn script
+```bash
+~/motley-crew/scripts/spawn-worker.sh <template> <repo_url>
+```
+
+This creates:
+- Worker with random human name
+- Personalized SOUL.md from template
+- Fresh code checkout with git identity configured
+- IDENTITY.md, AGENTS.md, initial memory
+
+### Step 3: Report
+Tell the user:
+- Worker name (e.g., "Alice Sonnet Developer")
+- Workspace path
+- Template used
+- That the worker is ready for task assignment
+
+## Available Templates
+
+| Template | Model | Role |
+|----------|-------|------|
+| `dev-opus` | Opus | Senior developer (complex tasks) |
+| `dev-sonnet` | Sonnet | Developer (standard tasks) |
+| `dev-haiku` | Haiku | Developer (simple/fast tasks) |
+| `dev-grok` | Grok | Developer (evaluation) |
+| `dev-minimax` | MiniMax | Developer (evaluation) |
+| `reviewer-opus` | Opus | Code reviewer |
+| `qa-sonnet` | Sonnet | QA / test writer |
+| `docs-sonnet` | Sonnet | Documentation writer |
+
+## Notes
+- Workers are permanent — they persist until the project is removed
+- They cost nothing when idle (no running process)
+- Each worker gets its own code checkout (no conflicts)

--- a/commands/mcworkers.md
+++ b/commands/mcworkers.md
@@ -1,0 +1,37 @@
+# /mcworkers — List Active Workers
+
+When the user sends `/mcworkers`, list all workers.
+
+## Scoping
+
+1. Read `IDENTITY.md` to determine your role.
+2. **If Project Lead:** List workers for this project only (filter by repo URL).
+3. **If Chief of Staff:** List all workers across all projects.
+
+## Workflow
+
+### Step 1: Run list script
+```bash
+~/motley-crew/scripts/list-workers.sh
+```
+
+This outputs a table:
+```
+NAME         TEMPLATE        ROLE       MODEL    CREATED
+----         --------        ----       -----    -------
+Alice        dev-sonnet      Developer  Sonnet   2026-02-20
+Bob          reviewer-opus   Reviewer   Opus     2026-02-20
+```
+
+### Step 2: Filter (if Lead)
+
+If you're a project lead, filter the output to only show workers whose `Project repo` in IDENTITY.md matches your project's repo URL.
+
+### Step 3: Report
+
+Post the table to the Discord channel. If no workers exist, say so and suggest `/mcworker <template>` to create one.
+
+## Notes
+- Workers are permanent and cost nothing when idle
+- Use `/mcworker <template>` to spawn new workers
+- Workers are only removed when a project is offboarded

--- a/scripts/onboard-project.sh
+++ b/scripts/onboard-project.sh
@@ -251,6 +251,14 @@ cat > "$LEAD_WORKSPACE/memory/$(date +%Y-%m-%d).md" << ENDDAY
 - Status: Awaiting initial codebase review
 ENDDAY
 
+# Copy command runbooks
+COMMANDS_DIR="$REPO_ROOT/commands"
+if [ -d "$COMMANDS_DIR" ]; then
+    mkdir -p "$LEAD_WORKSPACE/commands"
+    cp "$COMMANDS_DIR"/*.md "$LEAD_WORKSPACE/commands/"
+    echo "  Copied command runbooks to workspace"
+fi
+
 echo "  Created workspace at $LEAD_WORKSPACE"
 
 # --- Step 3: Clone repository ---
@@ -274,6 +282,7 @@ cat > "$CONFIG_DIR/projects/${PROJECT}.json" << ENDJSON
 {
   "name": "$PROJECT",
   "repo": "$REPO_URL",
+  "github_repo": "$(echo "$REPO_URL" | sed 's|.*github.com[:/]||; s|\.git$||')",
   "lead_agent_id": "$AGENT_ID",
   "lead_name": "$LEAD_NAME",
   "discord_channel_id": "$CHANNEL_ID",

--- a/scripts/sync-commands.sh
+++ b/scripts/sync-commands.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# sync-commands.sh — Copy command runbooks to all agent workspaces
+#
+# Usage: sync-commands.sh [agents-root]
+#
+# Copies commands/*.md from the motley-crew repo to:
+#   - CoS workspace (~/agents/cos/commands/)
+#   - All lead workspaces (~/agents/leads/*/commands/)
+#
+# Run this after updating command runbooks.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+COMMANDS_DIR="$REPO_ROOT/commands"
+AGENTS_ROOT="${1:-$HOME/agents}"
+
+if [ ! -d "$COMMANDS_DIR" ]; then
+    echo "ERROR: No commands directory at $COMMANDS_DIR"
+    exit 1
+fi
+
+COUNT=0
+
+# CoS
+COS_DIR="$AGENTS_ROOT/cos/commands"
+if [ -d "$AGENTS_ROOT/cos" ]; then
+    mkdir -p "$COS_DIR"
+    cp "$COMMANDS_DIR"/*.md "$COS_DIR/"
+    echo "  Updated: cos"
+    COUNT=$((COUNT + 1))
+fi
+
+# Leads
+if [ -d "$AGENTS_ROOT/leads" ]; then
+    for lead_dir in "$AGENTS_ROOT/leads"/*/; do
+        [ -d "$lead_dir" ] || continue
+        mkdir -p "${lead_dir}commands"
+        cp "$COMMANDS_DIR"/*.md "${lead_dir}commands/"
+        name=$(basename "$lead_dir")
+        echo "  Updated: $name"
+        COUNT=$((COUNT + 1))
+    done
+fi
+
+echo "Synced commands to $COUNT agent(s)."


### PR DESCRIPTION
Closes #17

## What

Four universal `/mc` commands that work the same way in every project, auto-scoped by agent role:

| Command | CoS (#command) | Lead (#project) |
|---------|---------------|------------------|
| `/mcstatus` | All projects summary | This project only |
| `/mcimplement <issue>` | Delegates to lead | Runs directly |
| `/mcworker <template>` | — | Spawns for this project |
| `/mcworkers` | All workers | This project workers |

## Files

- `commands/mcstatus.md` — Issues status email runbook
- `commands/mcimplement.md` — Implement → review → merge pipeline
- `commands/mcworker.md` — Spawn permanent worker from template
- `commands/mcworkers.md` — List active workers
- `scripts/sync-commands.sh` — Copy runbooks to all agent workspaces (CoS + leads)
- `scripts/onboard-project.sh` — Updated to copy commands during onboarding + added `github_repo` to project config

## Scoping mechanism

Each runbook starts by reading `IDENTITY.md` to determine if the agent is CoS or a project lead. Leads read their project config from `~/.config/motley-crew/projects/<name>.json`. CoS iterates over all project configs.

## Deployment

1. Run `scripts/sync-commands.sh` to copy runbooks to existing agents
2. New projects get commands automatically via `onboard-project.sh`
3. Register commands in OpenClaw config (`commands` section)