### PR TITLE
fix: correct script paths in mcworker and mcworkers runbooks

### DIFF
--- a/commands/mcworker.md
+++ b/commands/mcworker.md
@@ -17,13 +17,13 @@ When the user sends `/mcworker <template>`, spawn a new permanent worker for thi
 ### Step 1: Validate template
 Check that the template exists:
 ```bash
-ls ~/motley-crew/templates/<template>.md
+ls ~/Documents/motley-crew/templates/<template>.md
 ```
 If not found, list available templates and ask the user to pick one.
 
 ### Step 2: Run spawn script
 ```bash
-~/motley-crew/scripts/spawn-worker.sh <template> <repo_url>
+~/Documents/motley-crew/scripts/spawn-worker.sh <template> <repo_url>
 ```
 
 This creates:

--- a/commands/mcworkers.md
+++ b/commands/mcworkers.md
@@ -12,7 +12,7 @@ When the user sends `/mcworkers`, list all workers.
 
 ### Step 1: Run list script
 ```bash
-~/motley-crew/scripts/list-workers.sh
+~/Documents/motley-crew/scripts/list-workers.sh
 ```
 
 This outputs a table:


### PR DESCRIPTION
## Problem

`mcworker.md` and `mcworkers.md` referenced `~/motley-crew/` but the actual install path on the Mac Mini is `~/Documents/motley-crew/`.

## Changes

- `commands/mcworker.md`: `~/motley-crew/templates/` → `~/Documents/motley-crew/templates/`
- `commands/mcworker.md`: `~/motley-crew/scripts/spawn-worker.sh` → `~/Documents/motley-crew/scripts/spawn-worker.sh`
- `commands/mcworkers.md`: `~/motley-crew/scripts/list-workers.sh` → `~/Documents/motley-crew/scripts/list-workers.sh`