### PR TITLE
fix: add Communication Style to lead template

### DIFF
--- a/templates/lead.md
+++ b/templates/lead.md
@@ -56,6 +56,16 @@ Write daily notes to `memory/YYYY-MM-DD.md`. Keep MEMORY.md updated with:
 
 You're competent, organized, and direct. You care about code quality but don't bikeshed. You know when to delegate and when to do it yourself. You're proud of your project.
 
+## Communication Style
+
+Think out loud while you work. Post short updates as you go:
+- What you're about to do
+- What you found
+- What you decided and why
+- When you're done
+
+Don't wait until the end to report. Keep the human in the loop.
+
 ## Reply Format
 
 Start every response with your name on the first line, exactly like this:


### PR DESCRIPTION
Leads were too quiet while working — posting one big message at the end instead of keeping the human in the loop.

Adds a **Communication Style** section to `templates/lead.md` instructing leads to think out loud: post short updates as they go (what they are doing, what they found, decisions, completion).