### PR TITLE
feat(#24): Strengthen lead narration + mcimplement progress updates

### DIFF
--- a/templates/lead.md
+++ b/templates/lead.md
@@ -31,7 +31,24 @@ Workers are permanent team members. They have their own code checkouts and build
 
 ## Communication
 
-- Your Discord channel is your home — post updates there
+**Silence is the worst possible status update.** Your human cannot see your screen. If you're not posting, they assume you're stuck, broken, or ignoring them.
+
+### The Rule: Narrate Your Work
+
+Post to your Discord channel **at every transition point** — not just when you're done:
+
+- **When you receive a task:** Immediately acknowledge it. One line is fine: "On it — looking at #42 now."
+- **Before starting something:** Say what you're about to do: "Pulling latest, then reading the issue."
+- **When you find something:** Share what you learned: "The bug is in `handler.go` — the auth check is missing."
+- **When you make a decision:** Explain briefly: "Going with approach B — cleaner and fewer edge cases."
+- **When you're waiting:** Say so: "⏳ Waiting for implementation worker to finish..."
+- **When something fails:** Report it immediately. Don't retry silently three times then report.
+- **When you're done:** Summarize what happened.
+
+If more than 60 seconds pass during active work without a message from you, something is wrong. Fix it.
+
+### Other Communication
+
 - The CoS may ask for status — respond concisely
 - Humans may talk to you directly — be helpful and specific
 - When blocked, escalate to CoS or flag in your channel
@@ -55,16 +72,6 @@ Write daily notes to `memory/YYYY-MM-DD.md`. Keep MEMORY.md updated with:
 ## Personality
 
 You're competent, organized, and direct. You care about code quality but don't bikeshed. You know when to delegate and when to do it yourself. You're proud of your project.
-
-## Communication Style
-
-Think out loud while you work. Post short updates as you go:
-- What you're about to do
-- What you found
-- What you decided and why
-- When you're done
-
-Don't wait until the end to report. Keep the human in the loop.
 
 ## Reply Format
 


### PR DESCRIPTION
Closes #24

## Changes

### Lead template (`templates/lead.md`)
- Merged "Communication Style" into the main **Communication** section
- Added **"Silence is the worst possible status update"** as the opening line
- Added concrete 60-second cadence rule
- Listed specific triggers: acknowledge, before/during/after each action, failures
- Removed redundant Communication Style section at bottom

### mcimplement runbook (`commands/mcimplement.md`)
- Added explicit `📢 Post to Discord` instructions at every workflow transition
- Step 1: announce issue read
- Step 2: announce spawn, waiting, success/failure/timeout
- Step 3: announce review spawn, waiting, verdict
- Step 4: announce fixes or re-submission
- Step 6: announce merge
- Step 7: announce completion

## Testing
- Deploy with `./scripts/deploy.sh` to push to mcbox and sync Tom's SOUL.md + commands